### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 php:
+- '7.1'
 - '7.2.10'
 before_script:
   - composer self-update
   - composer install --no-interaction
 
 script:
-  - vendor/phpunit/phpunit/phpunit tests/testRandomDots.php
+  - vendor/phpunit/phpunit/phpunit -c tests/phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Function to add one or more dots in a random position of a string",
     "type": "project",
     "require": {
+        "php": ">=7.1",
         "phpunit/phpunit": "^7.4@dev"
     },
     "require-dev": {
@@ -16,10 +17,6 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "Elminson\\RandomDots\\": "src/",
-            "Elminson\\RandomDots\\Test\\": "tests/"
-        },
         "psr-4": {
             "Elminson\\RandomDots\\": "src/",
             "Elminson\\RandomDots\\Test\\": "tests/"

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,9 +1,13 @@
-<phpunit bootstrap="src/autoload.php">
-  <testsuites>
-    <testsuite name="RandomDots">
-      <file>tests/testRandomDots.php</file>
-      <directory>tests/*Test.php</directory>
-      <exclude></exclude>
-    </testsuite>
-  </testsuites>
+<?xml version="1.0"?>
+<phpunit colors="true" bootstrap="../vendor/autoload.php">
+    <testsuites>
+        <testsuite name="RandomDots">
+            <directory suffix=".php">./</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/testRandomDots.php
+++ b/tests/testRandomDots.php
@@ -8,8 +8,6 @@
 
 namespace Elminson\RandomDots;
 
-require __DIR__.'/../vendor/autoload.php';
-
 use PHPUnit\Framework\TestCase;
 
 class testRandomDots extends TestCase
@@ -23,5 +21,19 @@ class testRandomDots extends TestCase
         $randomdots = new RandomDots();
         $this->assertEquals("t.e.s.t", $randomdots->placeDot("test", 3));
         $this->assertEquals("r.a.n.d.o.m", $randomdots->placeDot("random", 5));
+    }
+
+    public function testPlaceDotOnInvalidStringLength()
+    {
+        $randomdots = new RandomDots();
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(" String length must be greater than number of dots ");
+        $randomdots->placeDot("");
+    }
+
+    public function testIndex()
+    {
+        $randomdots = new RandomDots();
+        $this->assertEquals("index", $randomdots->index());
     }
 }


### PR DESCRIPTION
# Changed log
- Using the `psr-4` autloader because the `psr-0` autoloader is deprecated.
- Using the correct `phpunit.xml.dist` file.
- Add the `"php": ">=7.1"` inside `require` block in `composer.json`.
- Add the missed test cases.